### PR TITLE
Fix layout collapse when scaling down

### DIFF
--- a/pytry/style/style.css
+++ b/pytry/style/style.css
@@ -92,9 +92,10 @@ h1 {
 
 .left-column {
   float: left;
-  width: calc(60% - 1px);
+  width: 60%;
   height: 100%;
   border-right: 1px solid #ddd;
+  box-sizing: border-box;
 }
 
 .right-column {


### PR DESCRIPTION
ブラウザを縮小表示した時に、一定の度合いを超えるとレイアウトが崩れて、入力・出力カラムが下に飛ぶ問題を修正。

具体的な発生条件: window.devicePixelRatio が 1 を下回ったとき
確認環境: Chrome, Firefox on Windows
修正方法: `box-sizing: border-box;` を指定することで、border の計算を内側要素に含むようにした。